### PR TITLE
Fix clang build error

### DIFF
--- a/include/xlnt/utils/exceptions.hpp
+++ b/include/xlnt/utils/exceptions.hpp
@@ -111,6 +111,7 @@ public:
     virtual ~invalid_sheet_title();
 };
 
+/* Compile error clang
 /// <summary>
 /// Exception when a referenced number format is not in the stylesheet.
 /// </summary>
@@ -132,6 +133,7 @@ public:
     /// </summary>
     virtual ~missing_number_format();
 };
+*/
 
 /// <summary>
 /// Exception for trying to open a non-XLSX file.

--- a/source/utils/exceptions.cpp
+++ b/source/utils/exceptions.cpp
@@ -41,9 +41,11 @@ void exception::message(const std::string &message)
     message_ = message;
 }
 
+/* Compile error clang
 missing_number_format::~missing_number_format()
 {
 }
+*/
 
 unhandled_switch_case::unhandled_switch_case()
     : xlnt::exception("unhandled switch case")


### PR DESCRIPTION
Issue: comment out the unused class missing_number_format in order to fix clang compile error